### PR TITLE
Update RCON Disposal

### DIFF
--- a/src/CoreRCON/RCON.cs
+++ b/src/CoreRCON/RCON.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 
 namespace CoreRCON
 {
-    public sealed class RCON : IDisposable
+    public partial class RCON : IDisposable
     {
         internal static string Identifier = "";
 
@@ -252,13 +252,22 @@ namespace CoreRCON
 
         public void Dispose()
         {
-            _connected = false;
-            _semaphoreSlim?.Dispose();
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
 
-            if (_tcp != null)
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
             {
-                _tcp.Shutdown(SocketShutdown.Both);
-                _tcp.Dispose();
+                _connected = false;
+                _semaphoreSlim?.Dispose();
+
+                if (_tcp != null)
+                {
+                    _tcp.Shutdown(SocketShutdown.Both);
+                    _tcp.Dispose();
+                }
             }
         }
 

--- a/src/CoreRCON/RCON.cs
+++ b/src/CoreRCON/RCON.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 
 namespace CoreRCON
 {
-    public partial class RCON : IDisposable
+    public sealed class RCON : IDisposable
     {
         internal static string Identifier = "";
 
@@ -58,7 +58,7 @@ namespace CoreRCON
         /// </summary>
         /// <param name="host">Server address</param>
         /// <param name="port">Server port</param>
-        public RCON(IPAddress host, ushort port, string password, uint timeout = 10000, 
+        public RCON(IPAddress host, ushort port, string password, uint timeout = 10000,
             bool sourceMultiPacketSupport = false, ILogger logger = null)
             : this(new IPEndPoint(host, port), password, timeout, sourceMultiPacketSupport, logger)
         { }
@@ -71,9 +71,9 @@ namespace CoreRCON
         /// <param name="timeout">Timeout to connect and send messages in milliseconds. A value of 0 means no timeout</param>
         /// <param name="sourceMultiPacketSupport">Enable source engine trick to receive multi packet responses using trick by Koraktor</param>
         /// <param name="logger">Logger to use, null means none</param>
-        public RCON(IPEndPoint endpoint, string password, 
-            uint timeout = 10000, 
-            bool sourceMultiPacketSupport = false, 
+        public RCON(IPEndPoint endpoint, string password,
+            uint timeout = 10000,
+            bool sourceMultiPacketSupport = false,
             ILogger logger = null)
         {
             _endpoint = endpoint;
@@ -253,8 +253,13 @@ namespace CoreRCON
         public void Dispose()
         {
             _connected = false;
-            _tcp.Shutdown(SocketShutdown.Both);
-            _tcp.Dispose();
+            _semaphoreSlim?.Dispose();
+
+            if (_tcp != null)
+            {
+                _tcp.Shutdown(SocketShutdown.Both);
+                _tcp.Dispose();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This PR addresses issues with the implementation of `RCON.Dispose`:
- implement "Dispose" pattern ([CA1816](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1816); _I'd prefer `sealed RCON`, but that could be a breaking change_)
- ensure SemaphoreSlim is disposed of
- avoid NullReferenceException if Socket has not been created yet