### PR TITLE
PR, Palworld Support (Tested on Minecraft and PalWorld)

### DIFF
--- a/src/CoreRCON/Constants.cs
+++ b/src/CoreRCON/Constants.cs
@@ -16,7 +16,12 @@
         /// <summary>
         /// The size of the header of an RCON packet.
         /// </summary>
-        internal const int PACKET_HEADER_SIZE = 12;
+        internal const int PACKET_HEADER_SIZE = 8;
+
+        /// <summary>
+        /// The size of the header of an RCON packet.
+        /// </summary>
+        internal const int PACKET_PADDING_SIZE = 2;
 
         /// <summary>
         /// Special response value when you send a Response.Response to the server.

--- a/src/CoreRCON/Constants.cs
+++ b/src/CoreRCON/Constants.cs
@@ -12,11 +12,12 @@
         /// Minimum size of a rcon packet
         /// </summary>
         internal const int MIN_PACKET_SIZE = 14;
-
+        
+        
         /// <summary>
         /// The size of the header of an RCON packet.
         /// </summary>
-        internal const int PACKET_HEADER_SIZE = 8;
+        internal const int PACKET_HEADER_SIZE = 12;
 
         /// <summary>
         /// The size of the header of an RCON packet.
@@ -28,5 +29,6 @@
         /// Used to finde the end of a multi packet response.
         /// </summary>
         internal const string MULTI_PACKET_END_RESPONSE = "\0\u0001\0\0";
+        
     }
 }

--- a/src/CoreRCON/Exceptions.cs
+++ b/src/CoreRCON/Exceptions.cs
@@ -19,4 +19,19 @@ namespace CoreRCON
         {
         }
     }
+
+    public class AuthenticationFailedException : AuthenticationException
+    {
+        public AuthenticationFailedException()
+        {
+        }
+
+        public AuthenticationFailedException(string message) : base(message)
+        {
+        }
+
+        public AuthenticationFailedException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
 }

--- a/src/CoreRCON/Extensions.cs
+++ b/src/CoreRCON/Extensions.cs
@@ -164,11 +164,9 @@ namespace CoreRCON
                 {
                     throw new TimeoutException();
                 }
-                else
-                {
-                    // Cancel the timer task so that it does not fire
-                    cts.Cancel();
-                }
+
+                // Cancel the timer task so that it does not fire
+                cts.Cancel();
                 await task;
             }
         }

--- a/src/CoreRCON/Extensions.cs
+++ b/src/CoreRCON/Extensions.cs
@@ -134,18 +134,16 @@ namespace CoreRCON
             {
                 var delayTask = Task.Delay(timeout.Value, cts.Token);
 
-                var resultTask = await Task.WhenAny(task, delayTask);
+                var resultTask = await Task.WhenAny(task, delayTask).ConfigureAwait(false);
                 if (resultTask == delayTask)
                 {
                     // Operation cancelled
                     throw new TimeoutException();
                 }
-                else
-                {
-                    cts.Cancel();
-                }
 
-                return await task;
+                cts.Cancel();
+
+                return await task.ConfigureAwait(false);
             }
         }
 

--- a/src/CoreRCON/PacketFormats/RCONPacket.cs
+++ b/src/CoreRCON/PacketFormats/RCONPacket.cs
@@ -69,14 +69,16 @@ namespace CoreRCON.PacketFormats
         internal byte[] ToBytes()
         {
             int bodyLength = Encoding.UTF8.GetByteCount(Body);
-            int size = Constants.PACKET_HEADER_SIZE + Constants.PACKET_PADDING_SIZE + bodyLength;
+            //
+            int packetSize = Constants.PACKET_HEADER_SIZE + Constants.PACKET_PADDING_SIZE + bodyLength;
             
-            byte[] packetBytes = new byte[size+4];
+            byte[] packetBytes = new byte[packetSize];
             Span<byte> packetSpan = packetBytes;
 
             // Write packet size
             // Packet size parameter does not include the size of the size parameter itself
-            BinaryPrimitives.WriteInt32LittleEndian(packetSpan, size);
+            var normalizedPacketSize = packetSize - 4;
+            BinaryPrimitives.WriteInt32LittleEndian(packetSpan, normalizedPacketSize); 
             packetSpan = packetSpan.Slice(4);
 
             // Write ID
@@ -87,7 +89,7 @@ namespace CoreRCON.PacketFormats
             BinaryPrimitives.WriteInt32LittleEndian(packetSpan, (int)Type);
 
             // Write body
-            Encoding.UTF8.GetBytes(Body, 0, Body.Length, packetBytes, 12);
+            Encoding.UTF8.GetBytes(Body, 0, Body.Length, packetBytes, Constants.PACKET_HEADER_SIZE);
             
             packetBytes[packetBytes.Length - 2] = 0; // Null terminator for the body
             packetBytes[packetBytes.Length - 1] = 0; // Null terminator for the package

--- a/src/CoreRCON/PacketFormats/RCONPacket.cs
+++ b/src/CoreRCON/PacketFormats/RCONPacket.cs
@@ -85,7 +85,6 @@ namespace CoreRCON.PacketFormats
 
             // Write type
             BinaryPrimitives.WriteInt32LittleEndian(packetSpan, (int)Type);
-            //packetSpan = packetSpan.Slice(4);
 
             // Write body
             Encoding.UTF8.GetBytes(Body, 0, Body.Length, packetBytes, 12);

--- a/src/CoreRCON/PacketFormats/RCONPacket.cs
+++ b/src/CoreRCON/PacketFormats/RCONPacket.cs
@@ -68,14 +68,15 @@ namespace CoreRCON.PacketFormats
         /// <returns>Byte array with each field.</returns>
         internal byte[] ToBytes()
         {
-            int bodyLength = Encoding.UTF8.GetByteCount(Body) + 1;
-            int totalLength = Constants.PACKET_HEADER_SIZE + bodyLength;
-            byte[] packetBytes = new byte[totalLength];
+            int bodyLength = Encoding.UTF8.GetByteCount(Body);
+            int size = Constants.PACKET_HEADER_SIZE + Constants.PACKET_PADDING_SIZE + bodyLength;
+            
+            byte[] packetBytes = new byte[size+4];
             Span<byte> packetSpan = packetBytes;
 
             // Write packet size
             // Packet size parameter does not include the size of the size parameter itself
-            BinaryPrimitives.WriteInt32LittleEndian(packetSpan, totalLength - 4);
+            BinaryPrimitives.WriteInt32LittleEndian(packetSpan, size);
             packetSpan = packetSpan.Slice(4);
 
             // Write ID
@@ -84,12 +85,13 @@ namespace CoreRCON.PacketFormats
 
             // Write type
             BinaryPrimitives.WriteInt32LittleEndian(packetSpan, (int)Type);
-            packetSpan = packetSpan.Slice(4);
+            //packetSpan = packetSpan.Slice(4);
 
             // Write body
-            Encoding.UTF8.GetBytes(Body, 0, Body.Length, packetBytes, Constants.PACKET_HEADER_SIZE);
-            packetSpan[bodyLength - 1] = 0; // Null terminator for the body
-            packetBytes[totalLength - 1] = 0; // Null terminator for the package
+            Encoding.UTF8.GetBytes(Body, 0, Body.Length, packetBytes, 12);
+            
+            packetBytes[packetBytes.Length - 2] = 0; // Null terminator for the body
+            packetBytes[packetBytes.Length - 1] = 0; // Null terminator for the package
 
             return packetBytes;
         }

--- a/src/CoreRCON/RCON.cs
+++ b/src/CoreRCON/RCON.cs
@@ -183,11 +183,6 @@ namespace CoreRCON
                 await writer.CompleteAsync()
                     .ConfigureAwait(false);
                 _connected = false;
-                if (_pipeCts != null && !_pipeCts.IsCancellationRequested)
-                {
-                    _pipeCts.Cancel(); // Tell reader to stop waiting
-                    _pipeCts = null;
-                }
                 OnDisconnected?.Invoke();
             }
         }

--- a/src/CoreRCON/RCON.cs
+++ b/src/CoreRCON/RCON.cs
@@ -446,7 +446,6 @@ namespace CoreRCON
             // Call pending result and remove from map
             if (!_pendingCommands.TryGetValue(packet.Id, out taskSource))
             {
-                _logger?.LogWarning("Received packet with no matching command id: {} body: {}", packet.Id, packet.Body);
                 // The server did not respect our id
                 if (!_strictCommandPacketIdMatching && packet.Id == 0)
                 {
@@ -456,6 +455,11 @@ namespace CoreRCON
                     // Get the most recently sent command
                     taskSource = nextCommandInQueue.Value;
                     packetId = nextCommandInQueue.Key;
+                }
+                else
+                {
+                    _logger?.LogWarning("Received packet with no matching command id: {} body: {}", packet.Id, packet.Body);
+                    return;
                 }
             }
 

--- a/src/RconShell/Program.cs
+++ b/src/RconShell/Program.cs
@@ -76,7 +76,7 @@ namespace RconShell
                 port
             );
 
-            rcon = new RCON(endpoint, password, 0);
+            rcon = new RCON(endpoint, password, 0, strictCommandPacketIdMatching: false);
             await rcon.ConnectAsync();
             bool connected = true;
             Console.WriteLine("Connected");

--- a/src/RconShell/Program.cs
+++ b/src/RconShell/Program.cs
@@ -79,7 +79,7 @@ namespace RconShell
             );
             bool connected = false;
             
-            rcon = new RCON(endpoint, password, 0, strictCommandPacketIdMatching: false, autoConnect: autoConnect);
+            rcon = new RCON(endpoint, password, 0, strictCommandPacketIdMatching: true, autoConnect: autoConnect);
             rcon.OnDisconnected += () =>
             {
                 Console.WriteLine("RCON Disconnected");
@@ -161,7 +161,7 @@ namespace RconShell
                     if (retry.ToLower() == "y")
                         break;
 
-                    if (retry.ToLower() == "y")
+                    if (retry.ToLower() == "n")
                     {
                         tryConnect = false;
                         break;

--- a/src/RconShell/Program.cs
+++ b/src/RconShell/Program.cs
@@ -79,7 +79,7 @@ namespace RconShell
             );
             bool connected = false;
             
-            rcon = new RCON(endpoint, password, 0, strictCommandPacketIdMatching: true, autoConnect: autoConnect);
+            rcon = new RCON(endpoint, password, 0, strictCommandPacketIdMatching: false, autoConnect: autoConnect);
             rcon.OnDisconnected += () =>
             {
                 Console.WriteLine("RCON Disconnected");

--- a/src/RconShell/Program.cs
+++ b/src/RconShell/Program.cs
@@ -43,14 +43,15 @@ namespace RconShell
         static async Task Main(string[] args)
         {
 
-
+            bool autoConnect = true;
             string host;
             int port = 0;
             string password;
 
-            Console.WriteLine("Enter Server Host/Ip");
+            Console.WriteLine("Enter Server Host/Ip (Default 127.0.0.1)");
 
-            host = Console.ReadLine();
+            var input = Console.ReadLine();
+            host = string.IsNullOrWhiteSpace(input) ? "127.0.0.1" : input;
 
             // Split host and port
             if (host.Contains(":"))
@@ -65,8 +66,9 @@ namespace RconShell
 
             if (port == 0)
             {
-                Console.WriteLine("Enter port (default 27055))");
-                port = int.Parse(Console.ReadLine() ?? "27055");
+                Console.WriteLine("Enter port (default 27055)");
+                input = Console.ReadLine();
+                port = int.Parse( string.IsNullOrWhiteSpace(input) ? "27055" : input);
             }
             Console.WriteLine("Enter password");
             password = Console.ReadLine();
@@ -75,42 +77,101 @@ namespace RconShell
                 addresses.First(),
                 port
             );
-
-            rcon = new RCON(endpoint, password, 0, strictCommandPacketIdMatching: false);
-            await rcon.ConnectAsync();
-            bool connected = true;
-            Console.WriteLine("Connected");
-
-            Console.WriteLine("You can now enter commands to send to server:");
+            bool connected = false;
+            
+            rcon = new RCON(endpoint, password, 0, strictCommandPacketIdMatching: false, autoConnect: autoConnect);
             rcon.OnDisconnected += () =>
             {
                 Console.WriteLine("RCON Disconnected");
                 connected = false;
             };
-
-            while (connected)
+            
+            var tryConnect = true;
+            do
             {
-                string command = Console.ReadLine();
-                if (command == "conctest")
+                try
                 {
-                    completed = 0;
-                    List<Thread> threadList = new List<Thread>(ThreadCount);
-                    for (int i = 0; i < ThreadCount; i++)
+                    await rcon.ConnectAsync();
+                    connected = true;
+                    Console.WriteLine($"Connected ({endpoint})");
+                    Console.WriteLine("You can now enter commands to send to server:");
+                    while (connected || autoConnect)
                     {
-                        ThreadStart childref = new ThreadStart(ConcurrentTestAsync);
-                        Thread childThread = new Thread(childref);
-                        childThread.Start();
-                        threadList.Add(childThread);
+                        string command = Console.ReadLine();
+                        if (!connected && !autoConnect)
+                            break;
+                        if (command == "conctest")
+                        {
+                            completed = 0;
+                            List<Thread> threadList = new List<Thread>(ThreadCount);
+                            for (int i = 0; i < ThreadCount; i++)
+                            {
+                                ThreadStart childref = new ThreadStart(ConcurrentTestAsync);
+                                Thread childThread = new Thread(childref);
+                                childThread.Start();
+                                threadList.Add(childThread);
+                            }
+
+                            while (completed < ThreadCount)
+                            {
+                                await Task.Delay(1);
+                            }
+
+                            continue;
+                        }
+
+                        try
+                        {
+                            string response = await rcon.SendCommandAsync(command);
+                            Console.WriteLine(response);
+                        }
+                        catch (ArgumentException ex)
+                        {
+                            var prevColor = Console.ForegroundColor;
+                            Console.ForegroundColor = ConsoleColor.Red;
+                            Console.WriteLine(ex.Message);
+                            Console.ForegroundColor = prevColor;
+                        }
                     }
-                    while (completed < ThreadCount)
-                    {
-                        await Task.Delay(1);
-                    }
+                }
+                catch (AuthenticationFailedException ex)
+                {
+                    var prevColor = Console.ForegroundColor;
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.WriteLine("Authentication failed: Invalid password");
+                    Console.ForegroundColor = prevColor;
+                    Console.WriteLine("Enter password");
+                    password = Console.ReadLine();
+                    rcon.SetPassword(password);
                     continue;
                 }
-                string response = await rcon.SendCommandAsync(command);
-                Console.WriteLine(response);
-            }
+                catch (Exception e)
+                {
+                    var prevColor = Console.ForegroundColor;
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.WriteLine(e);
+                    Console.ForegroundColor = prevColor;
+                    
+                }
+                
+                while (true)
+                {
+                    Console.WriteLine("Attempt to reconnect? (y/n)");
+                    var retry = Console.ReadLine();
+                    if (retry.ToLower() == "y")
+                        break;
+
+                    if (retry.ToLower() == "y")
+                    {
+                        tryConnect = false;
+                        break;
+                    }
+
+                    Console.WriteLine("Invalid input.");
+                }
+
+            } while (tryConnect);
+
         }
     }
 }

--- a/src/RconTest/RconTest.cs
+++ b/src/RconTest/RconTest.cs
@@ -54,7 +54,7 @@ namespace CoreRCON.Tests
             });
             ILogger<RCON> logger = loggerFactory.CreateLogger<RCON>();
 
-            rconClient = new RCON(_ip, _port, _password, 1000, false, logger);
+            rconClient = new RCON(_ip, _port, _password, 1000, false, true, logger);
             await rconClient.ConnectAsync();
         }
 


### PR DESCRIPTION
Fixes https://github.com/Challengermode/CoreRcon/issues/56

Updated the RCONPacket to use gorcon's implementation (https://github.com/gorcon/rcon/blob/master/packet.go).
This fixed the issues I was having with authentication, I suppose it should work with other servers since gorcon claims support with several.

Also added a parameter to RCON called strictCommandPacketIdMatching (default: true) which when enabled matches the command to the response packet (This was the existing behavior).

When set to false the command instead behaves as a queue and any response will complete the command taskSource.
This is because PalWorld always returns 0 for the response packet id (bad).

